### PR TITLE
fix(metadata): "Unsupported Widget" in Plasma 6.0 Beta 2

### DIFF
--- a/package/metadata.json
+++ b/package/metadata.json
@@ -21,7 +21,7 @@
     },
     "Keywords": "warp;zero;trust;cloudflare",
     "X-KDE-ParentApp": "warp-cli",
-    "X-KDE-Version": "6.0",
+    "X-Plasma-API-Minimum-Version": "6.0",
     "X-Plasma-NotificationArea": "true",
     "X-Plasma-NotificationAreaCategory": "ApplicationStatus",
     "X-Plasma-StandAloneApp": true


### PR DESCRIPTION
As of Plasma 6.0 Beta 2, it requires the X-Plasma-API-Minimum-Version key