### PR TITLE
Update Warp.qml

### DIFF
--- a/package/contents/ui/Warp.qml
+++ b/package/contents/ui/Warp.qml
@@ -33,7 +33,9 @@ Item {
     P5Support.DataSource {
         id: exec
         engine: "executable"
-        onNewData: disconnectSource
+        onNewData: (sourceName, data) => {
+            exec.disconnectSource(sourceName)
+        }
         readonly property var run: connectSource
     }
 


### PR DESCRIPTION
Fixes an issue where the widget would get stuck in a loop when trying to connect or disconnect. Previously, assigning `onNewData` directly to `disconnectSource` caused the widget to freeze after pressing the connect/disconnect button three times quickly. By updating `onNewData` to a function that explicitly calls `exec.disconnectSource(sourceName)`, this prevents the loop and ensures stable behavior.